### PR TITLE
Adding logic to eager evaluate async dependencies of indirect requests

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1245,7 +1245,7 @@ contributors: Nicolò Ribaudo
             </emu-alg>
 
             <emu-note>
-              <p>Step <emu-xref href="#step-BuildEvaluationList-all-importedNames"></emu-xref> is true when there's `import *`. Only asynchronous transitive dependencies of moudules loaded through `export defer` are evaluated at this point, while synchronous dependecies should not be evaluated. They will be evaluated by the module namespace exotic object <emu-xref href="#sec-module-namespace-exotic-objects-get-p-receiver">[[Get]]</emu-xref> internal method, upon access of the corresponding binding.</p>
+              <p>Step <emu-xref href="#step-BuildEvaluationList-all-importedNames"></emu-xref> is true when there's `import *`. For such case, only asynchronous transitive dependencies of modules loaded through `export defer` are evaluated at this point, while synchronous dependecies should not be evaluated. They will be evaluated by the module namespace exotic object <emu-xref href="#sec-module-namespace-exotic-objects-get-p-receiver">[[Get]]</emu-xref> internal method, upon access of the corresponding binding.</p>
             </emu-note>
 
             <emu-note>

--- a/spec.emu
+++ b/spec.emu
@@ -1234,8 +1234,12 @@ contributors: Nicolò Ribaudo
                   1. Append _requiredModule_ to _evaluationList_.
                 1. If _requiredModule_ is a Cyclic Module Record, then
                   1. Let _importedNames_ be _request_.[[ImportedNames]].
+                  1. Let _requestImportedNames_ be _importedNames_.
                   1. [id="step-BuildEvaluationList-reset-importedNames"] If _importedNames_ = ~all~, set _importedNames_ to « ».
                   1. Let _optionalIndirectRequests_ be _requiredModule_.GetOptionalIndirectExportsModuleRequests(_importedNames_).
+                  1. If _requestImportedNames_ = ~all~, then
+                    1. Let _seen_ be a new empty List.
+                    1. Perform ListAppendUnique(_evaluationList_, InnerGatherAsynchronousTransitiveDependencies(_requiredModule_, _optionalIndirectRequests_, _seen_)).
                   1. Perform BuildEvaluationList(_evaluationList_, _requiredModule_, _optionalIndirectRequests_).
               1. Return ~unused~.
             </emu-alg>

--- a/spec.emu
+++ b/spec.emu
@@ -1234,18 +1234,18 @@ contributors: Nicolò Ribaudo
                   1. Append _requiredModule_ to _evaluationList_.
                 1. If _requiredModule_ is a Cyclic Module Record, then
                   1. Let _importedNames_ be _request_.[[ImportedNames]].
-                  1. [id="step-BuildEvaluationList-reset-importedNames"] If _importedNames_ = ~all~, then
+                  1. If _importedNames_ = ~all~, then
                     1. Let _allOptionalIndirectRequests_ be _requiredModule_.GetOptionalIndirectExportsModuleRequests(_importedNames_).
                     1. Let _seen_ be a new empty List.
                     1. Perform ListAppendUnique(_evaluationList_, GatherAsynchronousTransitiveDependenciesForRequests(_requiredModule_, _allOptionalIndirectRequests_, _seen_)).
-                    1. Set _importedNames_ to « ».
+                    1. [id="step-BuildEvaluationList-reset-importedNames"] Set _importedNames_ to « ».
                   1. Let _optionalIndirectRequests_ be _requiredModule_.GetOptionalIndirectExportsModuleRequests(_importedNames_).
                   1. Perform BuildEvaluationList(_evaluationList_, _requiredModule_, _optionalIndirectRequests_).
               1. Return ~unused~.
             </emu-alg>
 
             <emu-note>
-              <p>Step <emu-xref href="#step-BuildEvaluationList-reset-importedNames"></emu-xref> empties _request_.[[ImportedNames]] when it's set to ~all~, so that `import *` does not cause the evaluation of modules loaded through `export defer`. They will be evaluated by the module namespace exotic object <emu-xref href="#sec-module-namespace-exotic-objects-get-p-receiver">[[Get]]</emu-xref> internal method, upon access of the corresponding binding.</p>
+              <p>Step <emu-xref href="#step-BuildEvaluationList-reset-importedNames"></emu-xref> empties _request_.[[ImportedNames]] when it's set to ~all~, so that `import *` causes the evaluation of only asynchronous dependencies of moudules loaded through `export defer`, while synchronous dependecies will not be evaluated. They will be evaluated by the module namespace exotic object <emu-xref href="#sec-module-namespace-exotic-objects-get-p-receiver">[[Get]]</emu-xref> internal method, upon access of the corresponding binding.</p>
             </emu-note>
 
             <emu-note>

--- a/spec.emu
+++ b/spec.emu
@@ -1234,18 +1234,18 @@ contributors: Nicolò Ribaudo
                   1. Append _requiredModule_ to _evaluationList_.
                 1. If _requiredModule_ is a Cyclic Module Record, then
                   1. Let _importedNames_ be _request_.[[ImportedNames]].
-                  1. If _importedNames_ = ~all~, then
+                  1. [id="step-BuildEvaluationList-all-importedNames"] If _importedNames_ = ~all~, then
                     1. Let _allOptionalIndirectRequests_ be _requiredModule_.GetOptionalIndirectExportsModuleRequests(_importedNames_).
                     1. Let _seen_ be a new empty List.
                     1. Perform ListAppendUnique(_evaluationList_, GatherAsynchronousTransitiveDependenciesForRequests(_requiredModule_, _allOptionalIndirectRequests_, _seen_)).
-                    1. [id="step-BuildEvaluationList-reset-importedNames"] Set _importedNames_ to « ».
-                  1. Let _optionalIndirectRequests_ be _requiredModule_.GetOptionalIndirectExportsModuleRequests(_importedNames_).
-                  1. Perform BuildEvaluationList(_evaluationList_, _requiredModule_, _optionalIndirectRequests_).
+                  1. Else,
+                    1. Let _optionalIndirectRequests_ be _requiredModule_.GetOptionalIndirectExportsModuleRequests(_importedNames_).
+                    1. Perform BuildEvaluationList(_evaluationList_, _requiredModule_, _optionalIndirectRequests_).
               1. Return ~unused~.
             </emu-alg>
 
             <emu-note>
-              <p>Step <emu-xref href="#step-BuildEvaluationList-reset-importedNames"></emu-xref> empties _request_.[[ImportedNames]] when it's set to ~all~, so that `import *` causes the evaluation of only asynchronous dependencies of moudules loaded through `export defer`, while synchronous dependecies will not be evaluated. They will be evaluated by the module namespace exotic object <emu-xref href="#sec-module-namespace-exotic-objects-get-p-receiver">[[Get]]</emu-xref> internal method, upon access of the corresponding binding.</p>
+              <p>Step <emu-xref href="#step-BuildEvaluationList-all-importedNames"></emu-xref> is true when there's `import *`. Only asynchronous transitive dependencies of moudules loaded through `export defer` are evaluated at this point, while synchronous dependecies should not be evaluated. They will be evaluated by the module namespace exotic object <emu-xref href="#sec-module-namespace-exotic-objects-get-p-receiver">[[Get]]</emu-xref> internal method, upon access of the corresponding binding.</p>
             </emu-note>
 
             <emu-note>

--- a/spec.emu
+++ b/spec.emu
@@ -1234,12 +1234,12 @@ contributors: Nicolò Ribaudo
                   1. Append _requiredModule_ to _evaluationList_.
                 1. If _requiredModule_ is a Cyclic Module Record, then
                   1. Let _importedNames_ be _request_.[[ImportedNames]].
-                  1. Let _requestImportedNames_ be _importedNames_.
-                  1. [id="step-BuildEvaluationList-reset-importedNames"] If _importedNames_ = ~all~, set _importedNames_ to « ».
-                  1. Let _optionalIndirectRequests_ be _requiredModule_.GetOptionalIndirectExportsModuleRequests(_importedNames_).
-                  1. If _requestImportedNames_ = ~all~, then
+                  1. [id="step-BuildEvaluationList-reset-importedNames"] If _importedNames_ = ~all~, then
+                    1. Let _allOptionalIndirectRequests_ be _requiredModule_.GetOptionalIndirectExportsModuleRequests(_importedNames_).
                     1. Let _seen_ be a new empty List.
-                    1. Perform ListAppendUnique(_evaluationList_, InnerGatherAsynchronousTransitiveDependencies(_requiredModule_, _optionalIndirectRequests_, _seen_)).
+                    1. Perform ListAppendUnique(_evaluationList_, GatherAsynchronousTransitiveDependenciesForRequests(_requiredModule_, _allOptionalIndirectRequests_, _seen_)).
+                    1. Set _importedNames_ to « ».
+                  1. Let _optionalIndirectRequests_ be _requiredModule_.GetOptionalIndirectExportsModuleRequests(_importedNames_).
                   1. Perform BuildEvaluationList(_evaluationList_, _requiredModule_, _optionalIndirectRequests_).
               1. Return ~unused~.
             </emu-alg>
@@ -1298,13 +1298,13 @@ contributors: Nicolò Ribaudo
                 1. <del>For each Module Record _m_ of _additionalModules_, do</del>
                   1. <del>If _result_ does not contain _m_, append _m_ to _result_.</del>
               1. <del>Return _result_.</del>
-              1. <ins>Return InnerGatherAsynchronousTransitiveDependencies(_module_, _module_.[[RequestedModules]], _seen_).</ins>
+              1. <ins>Return GatherAsynchronousTransitiveDependenciesForRequests(_module_, _module_.[[RequestedModules]], _seen_).</ins>
             </emu-alg>
 
-            <emu-clause id="sec-InnerGatherAsynchronousTransitiveDependencies" type="abstract operation">
+            <emu-clause id="sec-GatherAsynchronousTransitiveDependenciesForRequests" type="abstract operation">
               <h1>
                 <ins>
-                  InnerGatherAsynchronousTransitiveDependencies (
+                  GatherAsynchronousTransitiveDependenciesForRequests (
                     _referrer_: a Cyclic Module Record,
                     _moduleRequests_: a List of ModuleRequest Records,
                     _seen_: a List of Module Records
@@ -1322,7 +1322,7 @@ contributors: Nicolò Ribaudo
                   1. Let _requiredModule_ be GetImportedModule(_referrer_, _request_).
                   1. Perform ListAppendUnique(_result_, GatherAsynchronousTransitiveDependencies(_requiredModule_, _seen_)).
                   1. Let _optionalIndirectRequests_ be _requiredModule_.GetOptionalIndirectExportsModuleRequests(_request_.[[ImportedNames]]).
-                  1. Perform ListAppendUnique(_result_, InnerGatherAsynchronousTransitiveDependencies(_requiredModule_, _optionalIndirectRequests_, _seen_)).
+                  1. Perform ListAppendUnique(_result_, GatherAsynchronousTransitiveDependenciesForRequests(_requiredModule_, _optionalIndirectRequests_, _seen_)).
                 1. Return _result_.
               </emu-alg>
             </emu-clause>


### PR DESCRIPTION
This PR aligns the behavior for deferred re-exports with asynchronous dependencies with import defer, where it eagerly evaluates async dependencies when using namespaces, so we can properly execute `ns.deferred_export` synchronously.

It closes #23.