### PR TITLE
Validate optional re-exports when impoted through `*`

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1713,7 +1713,7 @@ contributors: Nicolò Ribaudo
               1. <ins>For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do</ins>
                 1. <ins>Let _importedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).</ins>
                 1. <ins>For each String _name_ of _importedModule_.GetExportedNames(), do</ins>
-                  1. <ins>NOTE: All exports of _importedModule_ other than `export defer` ones are already validated by the InitializeEnvironment call on _importedModule_ itself.</ins>
+                  1. <ins>NOTE: All exports of _importedModule_ other than `export defer` ones are also validated by the InitializeEnvironment call on _importedModule_ itself, and it is not observable which of the two InitializeEnvironment calls throws the *SyntaxError*.</ins>
                   1. <ins>If _name_ is not *"default"* and _importedModule_.ResolveExport(_name_) is *null*, throw a *SyntaxError* exception.</ins>
               1. Assert: All named exports from _module_ are resolvable.
               1. Let _realm_ be _module_.[[Realm]].
@@ -1724,7 +1724,7 @@ contributors: Nicolò Ribaudo
                 1. Let _importedModule_ be GetImportedModule(_module_, _in_.[[ModuleRequest]]).
                 1. If _in_.[[ImportName]] is ~namespace-object~, then
                   1. <ins>For each String _name_ of _importedModule_.GetExportedNames(), do</ins>
-                    1. <ins>NOTE: All exports of _importedModule_ other than `export defer` ones are already validated by the InitializeEnvironment call on _importedModule_ itself.</ins>
+                    1. <ins>NOTE: All exports of _importedModule_ other than `export defer` ones are also validated by the InitializeEnvironment call on _importedModule_ itself, and it is not observable which of the two InitializeEnvironment calls throws the *SyntaxError*.</ins>
                     1. <ins>If _importedModule_.ResolveExport(_name_) is *null*, throw a *SyntaxError* exception.</ins>
                   1. Let _namespace_ be GetModuleNamespace(_importedModule_, _in_.[[ModuleRequest]].[[Phase]]).
                   1. Perform ! _env_.CreateImmutableBinding(_in_.[[LocalName]], *true*).

--- a/spec.emu
+++ b/spec.emu
@@ -516,14 +516,12 @@ contributors: Nicolò Ribaudo
                   _exportName_: a String,
                   optional _resolveSet_: a List of Records with fields [[Module]] (a Module Record) and [[ExportName]] (a String),
                   <ins>optional _deferNamespaceExportSet_: a List of Module Records,</ins>
-                ): a ResolvedBinding Record, *null*, ~ambiguous~, or ~optional-namespace-unresolvable~
+                ): a ResolvedBinding Record, *null*, or ~ambiguous~
               </td>
               <td>
                 <p>It returns the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record" variants="ResolvedBinding Records">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String | ~namespace~ <ins>| ~deferred-namespace~</ins> }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to ~namespace~ <ins>or ~deferred-namespace~ (depending on whether the binding comes from a deferred import or not)</ins>. It returns *null* if the name cannot be resolved, or ~ambiguous~ if multiple bindings were found.</p>
                 <p>Each time this operation is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result.</p>
                 <p>LoadRequestedModules must have completed successfully prior to invoking this method.</p>
-
-                <emu-note type="editor"><p>~optional-namespace-unresolvable~ in the return type is an addition by this proposal, but Ecmarkup does not support marking it as such.</p></emu-note>
               </td>
               <td>
                 Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
@@ -1623,7 +1621,7 @@ contributors: Nicolò Ribaudo
                 _exportName_: a String,
                 optional _resolveSet_: a List of Records with fields [[Module]] (a Module Record) and [[ExportName]] (a String),
                 <ins>optional _deferNamespaceExportSet_: a List of Module Records</ins>
-              ): a ResolvedBinding Record, *null*, ~ambiguous~, or ~optional-namespace-unresolvable~
+              ): a ResolvedBinding Record, *null*, or ~ambiguous~
             </h1>
             <dl class="header">
               <dt>for</dt>
@@ -1632,10 +1630,9 @@ contributors: Nicolò Ribaudo
               <dt>description</dt>
               <dd>
                 <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is used to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
-                <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to ~namespace~. If no definition was found or the request is found to be circular, *null* is returned. <ins>If the request is found to be ambiguous, ~ambiguous~ is returned. If the request resolves to a deferred namespace declared through `export defer * as ...` whose corresponding module has a non-resolvable `export defer` declaration, ~optional-namespace-unresolvable~ is returned.</ins></p>
+                <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to ~namespace~. If no definition was found, the request is found to be circular, <ins>or if it resolves to a deferred namespace declared through `export defer * as ...` whose corresponding module has a non-resolvable `export defer` declaration,</ins> *null* is returned.</p>
               </dd>
             </dl>
-            <emu-note type="editor"><p>~optional-namespace-unresolvable~ in the return type is an addition by this proposal, but Ecmarkup does not support marking it as such.</p></emu-note>
 
             <emu-alg>
               1. Assert: _module_.[[Status]] is not ~new~.
@@ -1661,7 +1658,7 @@ contributors: Nicolò Ribaudo
                       1. <ins>Append _importedModule_ to _deferNamespaceExportSet_.</ins>
                       1. <ins>For each String _name_ of _importedModule_.GetExportedNames(), do</ins>
                         1. <ins>Let _resolution_ be _importedModule_.ResolveExport(_name_, « », _deferNamespaceExportSet_).</ins>
-                        1. <ins>If _resolution_ is *null* or _resolution_ is ~optional-namespace-unresolvable~, return ~optional-namespace-unresolvable~.</ins>
+                        1. <ins>If _resolution_ is *null*, return *null*.</ins>
                     1. If _e_.[[ModuleRequest]].[[Phase]] is ~defer~, then
                       1. Return ResolvedBinding Record { [[Module]]: _importedModule_, [[BindingName]]: ~deferred-namespace~ }.
                     1. Else,
@@ -1681,7 +1678,7 @@ contributors: Nicolò Ribaudo
                 1. Let _importedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).
                 1. Let _resolution_ be _importedModule_.ResolveExport(_exportName_, _resolveSet_, <ins>_deferNamespaceExportSet_</ins>).
                 1. If _resolution_ is ~ambiguous~, return ~ambiguous~.
-                1. <ins>If _resolution_ is ~optional-namespace-unresolvable~, return ~optional-namespace-unresolvable~.</ins>
+                1. <ins>NOTE: If _resolution_ is *null* because of an `export defer` declaration that re-exports a non-resolvable binding, it causes a *SyntaxError* to be thrown while linking _importedModule_ itself.</ins>
                 1. If _resolution_ is not *null*, then
                   1. Assert: _resolution_ is a ResolvedBinding Record.
                   1. If _starResolution_ is *null*, then
@@ -1711,13 +1708,13 @@ contributors: Nicolò Ribaudo
             <emu-alg>
               1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
                 1. Let _resolution_ be _module_.ResolveExport(_e_.[[ExportName]]).
-                1. If _resolution_ is either *null*, <ins>~optional-namespace-unresolvable~,</ins> or ~ambiguous~, throw a *SyntaxError* exception.
+                1. If _resolution_ is either *null* or ~ambiguous~, throw a *SyntaxError* exception.
                 1. Assert: _resolution_ is a ResolvedBinding Record.
               1. <ins>For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do</ins>
                 1. <ins>Let _importedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).</ins>
                 1. <ins>For each String _name_ of _importedModule_.GetExportedNames(), do</ins>
                   1. <ins>NOTE: All exports of _importedModule_ other than `export defer` ones are already validated by the InitializeEnvironment call on _importedModule_ itself.</ins>
-                  1. <ins>If _importedModule_.ResolveExport(_name_) is *null* or ~optional-namespace-unresolvable~, throw a *SyntaxError* exception.</ins>
+                  1. <ins>If _name_ is not *"default"* and _importedModule_.ResolveExport(_name_) is *null*, throw a *SyntaxError* exception.</ins>
               1. Assert: All named exports from _module_ are resolvable.
               1. Let _realm_ be _module_.[[Realm]].
               1. Assert: _realm_ is not *undefined*.
@@ -1728,13 +1725,13 @@ contributors: Nicolò Ribaudo
                 1. If _in_.[[ImportName]] is ~namespace-object~, then
                   1. <ins>For each String _name_ of _importedModule_.GetExportedNames(), do</ins>
                     1. <ins>NOTE: All exports of _importedModule_ other than `export defer` ones are already validated by the InitializeEnvironment call on _importedModule_ itself.</ins>
-                    1. <ins>If _importedModule_.ResolveExport(_name_) is *null* or ~optional-namespace-unresolvable~, throw a *SyntaxError* exception.</ins>
+                    1. <ins>If _importedModule_.ResolveExport(_name_) is *null*, throw a *SyntaxError* exception.</ins>
                   1. Let _namespace_ be GetModuleNamespace(_importedModule_, _in_.[[ModuleRequest]].[[Phase]]).
                   1. Perform ! _env_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
                   1. Perform ! _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
                 1. Else,
                   1. Let _resolution_ be _importedModule_.ResolveExport(_in_.[[ImportName]]).
-                  1. If _resolution_ is either *null*, <ins>~optional-namespace-unresolvable~,</ins> or ~ambiguous~, throw a *SyntaxError* exception.
+                  1. If _resolution_ is either *null* or ~ambiguous~, throw a *SyntaxError* exception.
                   1. If _resolution_.[[BindingName]] is ~namespace~ or ~deferred-namespace~, then
                     1. If _resolution_.[[BindingName]] is ~namespace~ let _phase_ be ~evaluation~, else let _phase_ be ~defer~.
                     1. Let _namespace_ be GetModuleNamespace(_resolution_.[[Module]], _phase_).

--- a/spec.emu
+++ b/spec.emu
@@ -515,12 +515,15 @@ contributors: Nicolò Ribaudo
                 ResolveExport (
                   _exportName_: a String,
                   optional _resolveSet_: a List of Records with fields [[Module]] (a Module Record) and [[ExportName]] (a String),
-                ): a ResolvedBinding Record, *null*, or ~ambiguous~
+                  <ins>optional _deferNamespaceExportSet_: a List of Module Records,</ins>
+                ): a ResolvedBinding Record, *null*, ~ambiguous~, or ~optional-namespace-unresolvable~
               </td>
               <td>
                 <p>It returns the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record" variants="ResolvedBinding Records">ResolvedBinding Record</dfn>, of the form { [[Module]]: Module Record, [[BindingName]]: String | ~namespace~ <ins>| ~deferred-namespace~</ins> }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to ~namespace~ <ins>or ~deferred-namespace~ (depending on whether the binding comes from a deferred import or not)</ins>. It returns *null* if the name cannot be resolved, or ~ambiguous~ if multiple bindings were found.</p>
                 <p>Each time this operation is called with a specific _exportName_, _resolveSet_ pair as arguments it must return the same result.</p>
                 <p>LoadRequestedModules must have completed successfully prior to invoking this method.</p>
+
+                <emu-note type="editor"><p>~optional-namespace-unresolvable~ in the return type is an addition by this proposal, but Ecmarkup does not support marking it as such.</p></emu-note>
               </td>
               <td>
                 Within this specification it has definitions in the following types; hosts may provide additional types with their own definitions:
@@ -1619,7 +1622,8 @@ contributors: Nicolò Ribaudo
               ResolveExport (
                 _exportName_: a String,
                 optional _resolveSet_: a List of Records with fields [[Module]] (a Module Record) and [[ExportName]] (a String),
-              ): a ResolvedBinding Record, *null*, or ~ambiguous~
+                <ins>optional _deferNamespaceExportSet_: a List of Module Records</ins>
+              ): a ResolvedBinding Record, *null*, ~ambiguous~, or ~optional-namespace-unresolvable~
             </h1>
             <dl class="header">
               <dt>for</dt>
@@ -1628,13 +1632,15 @@ contributors: Nicolò Ribaudo
               <dt>description</dt>
               <dd>
                 <p>ResolveExport attempts to resolve an imported binding to the actual defining module and local binding name. The defining module may be the module represented by the Module Record this method was invoked on or some other module that is imported by that module. The parameter _resolveSet_ is used to detect unresolved circular import/export paths. If a pair consisting of specific Module Record and _exportName_ is reached that is already in _resolveSet_, an import circularity has been encountered. Before recursively calling ResolveExport, a pair consisting of _module_ and _exportName_ is added to _resolveSet_.</p>
-                <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to ~namespace~. If no definition was found or the request is found to be circular, *null* is returned. If the request is found to be ambiguous, ~ambiguous~ is returned.</p>
+                <p>If a defining module is found, a ResolvedBinding Record { [[Module]], [[BindingName]] } is returned. This record identifies the resolved binding of the originally requested export, unless this is the export of a namespace with no local binding. In this case, [[BindingName]] will be set to ~namespace~. If no definition was found or the request is found to be circular, *null* is returned. <ins>If the request is found to be ambiguous, ~ambiguous~ is returned. If the request resolves to a deferred namespace declared through `export defer * as ...` whose corresponding module has a non-resolvable `export defer` declaration, ~optional-namespace-unresolvable~ is returned.</ins></p>
               </dd>
             </dl>
+            <emu-note type="editor"><p>~optional-namespace-unresolvable~ in the return type is an addition by this proposal, but Ecmarkup does not support marking it as such.</p></emu-note>
 
             <emu-alg>
               1. Assert: _module_.[[Status]] is not ~new~.
               1. If _resolveSet_ is not present, set _resolveSet_ to a new empty List.
+              1. <ins>If _deferNamespaceExportSet_ is not present, set _deferNamespaceExportSet_ to a new empty List.</ins>
               1. For each Record { [[Module]], [[ExportName]] } _r_ of _resolveSet_, do
                 1. If _module_ and _r_.[[Module]] are the same Module Record and _exportName_ is _r_.[[ExportName]], then
                   1. Assert: This is a circular import request.
@@ -1651,6 +1657,11 @@ contributors: Nicolò Ribaudo
                   1. Let _importedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).
                   1. If _e_.[[ImportName]] is ~all~, then
                     1. Assert: _module_ does not provide the direct binding for this export.
+                    1. <ins>If _module_.[[OptionalIndirectExportEntries]] contains _e_ and _deferNamespaceExportSet_ does not contain _importedModule_, then</ins>
+                      1. <ins>Append _importedModule_ to _deferNamespaceExportSet_.</ins>
+                      1. <ins>For each String _name_ of _importedModule_.GetExportedNames(), do</ins>
+                        1. <ins>Let _resolution_ be _importedModule_.ResolveExport(_name_, « », _deferNamespaceExportSet_).</ins>
+                        1. <ins>If _resolution_ is *null* or _resolution_ is ~optional-namespace-unresolvable~, return ~optional-namespace-unresolvable~.</ins>
                     1. If _e_.[[ModuleRequest]].[[Phase]] is ~defer~, then
                       1. Return ResolvedBinding Record { [[Module]]: _importedModule_, [[BindingName]]: ~deferred-namespace~ }.
                     1. Else,
@@ -1659,7 +1670,7 @@ contributors: Nicolò Ribaudo
                   1. Else,
                     1. Assert: _module_ imports a specific binding for this export.
                     1. Assert: _e_.[[ImportName]] is a String.
-                    1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_).
+                    1. Return _importedModule_.ResolveExport(_e_.[[ImportName]], _resolveSet_, <ins>_deferNamespaceExportSet_</ins>).
               1. If _exportName_ is *"default"*, then
                 1. Assert: A `default` export was not explicitly defined by this module.
                 1. Return *null*.
@@ -1668,8 +1679,9 @@ contributors: Nicolò Ribaudo
               1. For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do
                 1. Assert: _e_.[[ModuleRequest]] is not *null*.
                 1. Let _importedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).
-                1. Let _resolution_ be _importedModule_.ResolveExport(_exportName_, _resolveSet_).
+                1. Let _resolution_ be _importedModule_.ResolveExport(_exportName_, _resolveSet_, <ins>_deferNamespaceExportSet_</ins>).
                 1. If _resolution_ is ~ambiguous~, return ~ambiguous~.
+                1. <ins>If _resolution_ is ~optional-namespace-unresolvable~, return ~optional-namespace-unresolvable~.</ins>
                 1. If _resolution_ is not *null*, then
                   1. Assert: _resolution_ is a ResolvedBinding Record.
                   1. If _starResolution_ is *null*, then
@@ -1688,6 +1700,82 @@ contributors: Nicolò Ribaudo
           <h1>Implementation of Cyclic Module Record Abstract Methods</h1>
 
           <p>The following are the concrete methods for Source Text Module Record that implement the corresponding Cyclic Module Record abstract methods defined in <emu-xref href="#table-cyclic-module-methods"></emu-xref>.</p>
+
+          <emu-clause id="sec-source-text-module-record-initialize-environment" type="concrete method">
+            <h1>InitializeEnvironment ( ): either a normal completion containing ~unused~ or a throw completion</h1>
+            <dl class="header">
+              <dt>for</dt>
+              <dd>a Source Text Module Record _module_</dd>
+            </dl>
+
+            <emu-alg>
+              1. For each ExportEntry Record _e_ of _module_.[[IndirectExportEntries]], do
+                1. Let _resolution_ be _module_.ResolveExport(_e_.[[ExportName]]).
+                1. If _resolution_ is either *null*, <ins>~optional-namespace-unresolvable~,</ins> or ~ambiguous~, throw a *SyntaxError* exception.
+                1. Assert: _resolution_ is a ResolvedBinding Record.
+              1. <ins>For each ExportEntry Record _e_ of _module_.[[StarExportEntries]], do</ins>
+                1. <ins>Let _importedModule_ be GetImportedModule(_module_, _e_.[[ModuleRequest]]).</ins>
+                1. <ins>For each String _name_ of _importedModule_.GetExportedNames(), do</ins>
+                  1. <ins>NOTE: All exports of _importedModule_ other than `export defer` ones are already validated by the InitializeEnvironment call on _importedModule_ itself.</ins>
+                  1. <ins>If _importedModule_.ResolveExport(_name_) is *null* or ~optional-namespace-unresolvable~, throw a *SyntaxError* exception.</ins>
+              1. Assert: All named exports from _module_ are resolvable.
+              1. Let _realm_ be _module_.[[Realm]].
+              1. Assert: _realm_ is not *undefined*.
+              1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
+              1. Set _module_.[[Environment]] to _env_.
+              1. For each ImportEntry Record _in_ of _module_.[[ImportEntries]], do
+                1. Let _importedModule_ be GetImportedModule(_module_, _in_.[[ModuleRequest]]).
+                1. If _in_.[[ImportName]] is ~namespace-object~, then
+                  1. <ins>For each String _name_ of _importedModule_.GetExportedNames(), do</ins>
+                    1. <ins>NOTE: All exports of _importedModule_ other than `export defer` ones are already validated by the InitializeEnvironment call on _importedModule_ itself.</ins>
+                    1. <ins>If _importedModule_.ResolveExport(_name_) is *null* or ~optional-namespace-unresolvable~, throw a *SyntaxError* exception.</ins>
+                  1. Let _namespace_ be GetModuleNamespace(_importedModule_, _in_.[[ModuleRequest]].[[Phase]]).
+                  1. Perform ! _env_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
+                  1. Perform ! _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
+                1. Else,
+                  1. Let _resolution_ be _importedModule_.ResolveExport(_in_.[[ImportName]]).
+                  1. If _resolution_ is either *null*, <ins>~optional-namespace-unresolvable~,</ins> or ~ambiguous~, throw a *SyntaxError* exception.
+                  1. If _resolution_.[[BindingName]] is ~namespace~ or ~deferred-namespace~, then
+                    1. If _resolution_.[[BindingName]] is ~namespace~ let _phase_ be ~evaluation~, else let _phase_ be ~defer~.
+                    1. Let _namespace_ be GetModuleNamespace(_resolution_.[[Module]], _phase_).
+                    1. Perform ! _env_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
+                    1. Perform ! _env_.InitializeBinding(_in_.[[LocalName]], _namespace_).
+                  1. Else,
+                    1. Perform CreateImportBinding(_env_, _in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
+              1. Let _moduleContext_ be a new ECMAScript code execution context.
+              1. Set the Function of _moduleContext_ to *null*.
+              1. Assert: _module_.[[Realm]] is not *undefined*.
+              1. Set the Realm of _moduleContext_ to _module_.[[Realm]].
+              1. Set the ScriptOrModule of _moduleContext_ to _module_.
+              1. Set the VariableEnvironment of _moduleContext_ to _module_.[[Environment]].
+              1. Set the LexicalEnvironment of _moduleContext_ to _module_.[[Environment]].
+              1. Set the PrivateEnvironment of _moduleContext_ to *null*.
+              1. Set _module_.[[Context]] to _moduleContext_.
+              1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
+              1. Let _code_ be _module_.[[ECMAScriptCode]].
+              1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.
+              1. Let _declaredVarNames_ be a new empty List.
+              1. For each element _d_ of _varDeclarations_, do
+                1. For each element _dn_ of the BoundNames of _d_, do
+                  1. If _declaredVarNames_ does not contain _dn_, then
+                    1. Perform ! _env_.CreateMutableBinding(_dn_, *false*).
+                    1. Perform ! _env_.InitializeBinding(_dn_, *undefined*).
+                    1. Append _dn_ to _declaredVarNames_.
+              1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _code_.
+              1. Let _privateEnv_ be *null*.
+              1. For each element _d_ of _lexDeclarations_, do
+                1. For each element _dn_ of the BoundNames of _d_, do
+                  1. If IsConstantDeclaration of _d_ is *true*, then
+                    1. Perform ! _env_.CreateImmutableBinding(_dn_, *true*).
+                  1. Else,
+                    1. Perform ! _env_.CreateMutableBinding(_dn_, *false*).
+                  1. If _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
+                    1. Let _fo_ be InstantiateFunctionObject of _d_ with arguments _env_ and _privateEnv_.
+                    1. Perform ! _env_.InitializeBinding(_dn_, _fo_).
+              1. Remove _moduleContext_ from the execution context stack.
+              1. Return ~unused~.
+            </emu-alg>
+          </emu-clause>
 
           <emu-clause id="sec-GetOptionalIndirectExportsModuleRequests" type="concrete method" number="3">
             <h1>


### PR DESCRIPTION
Fixes https://github.com/tc39/proposal-deferred-reexports/issues/30

@caiolima I _think_ this works, but I'd appreciate if you could double-check.

This PR adds validation in a couple of places:
- in `InitializeEnvironment`, it checks that if I do `export * from "x"`, all optional re-export of `"x"` are valid (in the new `For each ExportEntry Record e of module.[[StarExportEntries]], do` loop)
- in `InitializeEnvironment`, it checks that if I do `import [defer] * as ns from "x"`, all optional re-export of `"x"` are valid (in the new `For each String name of importedModule.GetExportedNames(), do` loop inside the `If in.[[ImportName]] is namespace-object, then` step)

The definition of "valid" is now expanded to not only mean that `ResolveExport` is not null (or, in some cases, AMBIGUOUS): `ResolveExport` also has a new state, OPTIONAL-NAMESPACE-UNRESOLVABLE, which means "I found a `export defer * as ns from "x"` export, which I can resolve, but then `"x"` has an unresolvable `export defer`". This needs to be done as part of binding resolution because that's the first time we know if a deferred re-export actually needs to be checked or not. Note that `ResolveExport` itself must be pure and thus does not throw errors.