### PR TITLE
Fixing eager execution of asynchronous deps on dynamic imports

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -160,7 +160,15 @@ contributors: Nicolò Ribaudo
                 1. Let _evaluatePromise_ be SafePerformPromiseAll(_asyncDepsEvaluationPromises_).
               1. Else,
                 1. Assert: _phase_ is ~evaluation~.
-                1. Let _evaluatePromise_ be _module_.Evaluate(<ins>~all~</ins>).
+                1. <del>Let _evaluatePromise_ be _module_.Evaluate().</del>
+                1. <ins>Let _evaluationList_ be GatherAsynchronousTransitiveDependencies(_module_).</ins>
+                1. <ins>If _evaluationList_ is empty, then</ins>
+                  1. <ins>Let _evaluatePromise_ be _module_.Evaluate().</ins>
+                1. <ins>Else,</ins>
+                  1. <ins>Let _evaluationPromises_ be a new empty List.</ins>
+                  1. <ins>For each Module Record _dep_ of _evaluationList_, append _dep_.Evaluate() to _evaluationPromises_.</ins>
+                  1. <ins>Append _module_.Evaluate() to _evaluationPromises_.</ins>
+                  1. <ins>Let _evaluatePromise_ be SafePerformPromiseAll(_evaluationPromises_).</ins>
               1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, *""*, 0, &laquo; &raquo;).
               1. Perform PerformPromiseThen(_evaluatePromise_, _onFulfilled_, _onRejected_).
               1. Return ~unused~.

--- a/spec.emu
+++ b/spec.emu
@@ -152,6 +152,10 @@ contributors: Nicolò Ribaudo
                 1. Return ~unused~.
               1. If _phase_ is ~defer~, then
                 1. Let _evaluationList_ be GatherAsynchronousTransitiveDependencies(_module_).
+                1. <ins>If _module_ is a Cyclic Module Record, then</ins>
+                  1. <ins>Let _optionalIndirectRequests_ be _module_.GetOptionalIndirectExportsModuleRequests(~all~).</ins>
+                  1. <ins>Let _seen_ be a new empty List.</ins>
+                  1. <ins>Perform ListAppendUnique(_evaluationList_, GatherAsynchronousTransitiveDependenciesForRequests(_module_, _optionalIndirectRequests_, _seen_)).</ins>
                 1. If _evaluationList_ is empty, then
                   1. Perform _fulfilledClosure_().
                   1. Return ~unused~.
@@ -161,13 +165,16 @@ contributors: Nicolò Ribaudo
               1. Else,
                 1. Assert: _phase_ is ~evaluation~.
                 1. <del>Let _evaluatePromise_ be _module_.Evaluate().</del>
-                1. <ins>Let _evaluationList_ be GatherAsynchronousTransitiveDependencies(_module_).</ins>
-                1. <ins>If _evaluationList_ is empty, then</ins>
+                1. <ins>Let _asyncEvaluationList_ be a new empty List.</ins>
+                1. <ins>If _module_ is a Cyclic Module Record, then</ins>
+                  1. <ins>Let _optionalIndirectRequests_ be _module_.GetOptionalIndirectExportsModuleRequests(~all~).</ins>
+                  1. <ins>Let _seen_ be a new empty List.</ins>
+                  1. <ins>Perform ListAppendUnique(_asyncEvaluationList_, GatherAsynchronousTransitiveDependenciesForRequests(_module_, _optionalIndirectRequests_, _seen_)).</ins>
+                1. <ins>If _asyncEvaluationList_ is empty, then</ins>
                   1. <ins>Let _evaluatePromise_ be _module_.Evaluate().</ins>
                 1. <ins>Else,</ins>
-                  1. <ins>Let _evaluationPromises_ be a new empty List.</ins>
-                  1. <ins>For each Module Record _dep_ of _evaluationList_, append _dep_.Evaluate() to _evaluationPromises_.</ins>
-                  1. <ins>Append _module_.Evaluate() to _evaluationPromises_.</ins>
+                  1. <ins>Let _evaluationPromises_ be « _module_.Evaluate() ».</ins>
+                  1. <ins>For each Module Record _dep_ of _asyncEvaluationList_, append _dep_.Evaluate() to _evaluationPromises_.</ins>
                   1. <ins>Let _evaluatePromise_ be SafePerformPromiseAll(_evaluationPromises_).</ins>
               1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, *""*, 0, &laquo; &raquo;).
               1. Perform PerformPromiseThen(_evaluatePromise_, _onFulfilled_, _onRejected_).

--- a/spec.emu
+++ b/spec.emu
@@ -160,7 +160,7 @@ contributors: Nicolò Ribaudo
                 1. Let _evaluatePromise_ be SafePerformPromiseAll(_asyncDepsEvaluationPromises_).
               1. Else,
                 1. Assert: _phase_ is ~evaluation~.
-                1. Let _evaluatePromise_ be _module_.Evaluate().
+                1. Let _evaluatePromise_ be _module_.Evaluate(<ins>~all~</ins>).
               1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, *""*, 0, &laquo; &raquo;).
               1. Perform PerformPromiseThen(_evaluatePromise_, _onFulfilled_, _onRejected_).
               1. Return ~unused~.

--- a/spec.emu
+++ b/spec.emu
@@ -150,32 +150,31 @@ contributors: Nicolò Ribaudo
                 1. Let _namespace_ be GetModuleNamespace(_module_, _phase_).
                 1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _namespace_ &raquo;).
                 1. Return ~unused~.
-              1. If _phase_ is ~defer~, then
-                1. Let _evaluationList_ be GatherAsynchronousTransitiveDependencies(_module_).
-                1. <ins>If _module_ is a Cyclic Module Record, then</ins>
-                  1. <ins>Let _optionalIndirectRequests_ be _module_.GetOptionalIndirectExportsModuleRequests(~all~).</ins>
-                  1. <ins>Let _seen_ be a new empty List.</ins>
-                  1. <ins>Perform ListAppendUnique(_evaluationList_, GatherAsynchronousTransitiveDependenciesForRequests(_module_, _optionalIndirectRequests_, _seen_)).</ins>
-                1. If _evaluationList_ is empty, then
-                  1. Perform _fulfilledClosure_().
-                  1. Return ~unused~.
-                1. Let _asyncDepsEvaluationPromises_ be a new empty List.
-                1. For each Module Record _dep_ of _evaluationList_, append _dep_.Evaluate() to _asyncDepsEvaluationPromises_.
-                1. Let _evaluatePromise_ be SafePerformPromiseAll(_asyncDepsEvaluationPromises_).
-              1. Else,
-                1. Assert: _phase_ is ~evaluation~.
+              1. <del>If _phase_ is ~defer~, then </del>
+                1. <del>Let _evaluationList_ be GatherAsynchronousTransitiveDependencies(_module_).</del>
+                1. <del>If _evaluationList_ is empty, then</del>
+                  1. <del>Perform _fulfilledClosure_().</del>
+                  1. <del>Return ~unused~.</del>
+                1. <del>Let _asyncDepsEvaluationPromises_ be a new empty List.</del>
+                1. <del>For each Module Record _dep_ of _evaluationList_, append _dep_.Evaluate() to _asyncDepsEvaluationPromises_.</del>
+                1. <del>Let _evaluatePromise_ be SafePerformPromiseAll(_asyncDepsEvaluationPromises_).</del>
+              1. <del>Else,</del>
+                1. <del>Assert: _phase_ is ~evaluation~.</del>
                 1. <del>Let _evaluatePromise_ be _module_.Evaluate().</del>
-                1. <ins>Let _asyncEvaluationList_ be a new empty List.</ins>
-                1. <ins>If _module_ is a Cyclic Module Record, then</ins>
-                  1. <ins>Let _optionalIndirectRequests_ be _module_.GetOptionalIndirectExportsModuleRequests(~all~).</ins>
-                  1. <ins>Let _seen_ be a new empty List.</ins>
-                  1. <ins>Perform ListAppendUnique(_asyncEvaluationList_, GatherAsynchronousTransitiveDependenciesForRequests(_module_, _optionalIndirectRequests_, _seen_)).</ins>
-                1. <ins>If _asyncEvaluationList_ is empty, then</ins>
-                  1. <ins>Let _evaluatePromise_ be _module_.Evaluate().</ins>
-                1. <ins>Else,</ins>
-                  1. <ins>Let _evaluationPromises_ be « _module_.Evaluate() ».</ins>
-                  1. <ins>For each Module Record _dep_ of _asyncEvaluationList_, append _dep_.Evaluate() to _evaluationPromises_.</ins>
-                  1. <ins>Let _evaluatePromise_ be SafePerformPromiseAll(_evaluationPromises_).</ins>
+              1. <ins>If _phase_ is ~defer~, let _evaluationList_ be GatherAsynchronousTransitiveDependencies(_module_).</ins>
+              1. <ins>Else, let _evaluationList_ be << _module_ >>.</ins>
+              1. <ins>Let _optionalIndirectRequests_ be _module_.GetOptionalIndirectExportsModuleRequests(~all~).</ins>
+              1. <ins>Let _seen_ be a new empty List.</ins>
+              1. <ins>Perform ListAppendUnique(_evaluationList_, GatherAsynchronousTransitiveDependenciesForRequests(_module_, _optionalIndirectRequests_, _seen_)).</ins>
+              1. <ins>If _evaluationList_ is empty, then</ins>
+                  1. <ins>Perform _fulfilledClosure_().</ins>
+                  1. <ins>Return ~unused~.</ins>
+              1. <ins>If _phase_ is ~evaluation~ and _evaluationList_'s length is 1, then</ins>
+                1. <ins>Let _evaluatePromise_ be _module_.Evaluate().</ins>
+              1. <ins>Else,</ins>
+                1. <ins>Let _evaluationPromises_ be a new empty List.</ins>
+                1. <ins>For each Module Record _dep_ of _evaluationList_, append _dep_.Evaluate() to _evaluationPromises_.</ins>
+                1. <ins>Let _evaluatePromise_ be SafePerformPromiseAll(_evaluationPromises_).</ins>
               1. Let _onFulfilled_ be CreateBuiltinFunction(_fulfilledClosure_, *""*, 0, &laquo; &raquo;).
               1. Perform PerformPromiseThen(_evaluatePromise_, _onFulfilled_, _onRejected_).
               1. Return ~unused~.

--- a/spec.emu
+++ b/spec.emu
@@ -162,14 +162,14 @@ contributors: Nicolò Ribaudo
                 1. <del>Assert: _phase_ is ~evaluation~.</del>
                 1. <del>Let _evaluatePromise_ be _module_.Evaluate().</del>
               1. <ins>If _phase_ is ~defer~, let _evaluationList_ be GatherAsynchronousTransitiveDependencies(_module_).</ins>
-              1. <ins>Else, let _evaluationList_ be << _module_ >>.</ins>
+              1. <ins>Else, let _evaluationList_ be « _module_ ».</ins>
               1. <ins>Let _optionalIndirectRequests_ be _module_.GetOptionalIndirectExportsModuleRequests(~all~).</ins>
-              1. <ins>Let _seen_ be a new empty List.</ins>
-              1. <ins>Perform ListAppendUnique(_evaluationList_, GatherAsynchronousTransitiveDependenciesForRequests(_module_, _optionalIndirectRequests_, _seen_)).</ins>
+              1. <ins>Perform ListAppendUnique(_evaluationList_, GatherAsynchronousTransitiveDependenciesForRequests(_module_, _optionalIndirectRequests_, « »)).</ins>
               1. <ins>If _evaluationList_ is empty, then</ins>
-                  1. <ins>Perform _fulfilledClosure_().</ins>
-                  1. <ins>Return ~unused~.</ins>
-              1. <ins>If _phase_ is ~evaluation~ and _evaluationList_'s length is 1, then</ins>
+                1. <ins>Assert: _phase_ is ~defer~.</ins>
+                1. <ins>Perform _fulfilledClosure_().</ins>
+                1. <ins>Return ~unused~.</ins>
+              1. <ins>If the length of _evaluationList_ = 1, then</ins>
                 1. <ins>Let _evaluatePromise_ be _module_.Evaluate().</ins>
               1. <ins>Else,</ins>
                 1. <ins>Let _evaluationPromises_ be a new empty List.</ins>


### PR DESCRIPTION
The spec now doesn't properly handle eager evaluation of asynchronous deps on dynamic import(.defer) execution. This breaks the test case bellow:

```js
// entrypoint 
const ns = await import("./tla-barrel_FIXTURE.js");
const _x = ns.x;

// barrel
export defer { x } from "./tla";

// tla
await null;
export const x = "tla-x";
```

What we get is that we will call `6.e.ii. Let evaluatePromise be module.Evaluate()` with empty imported names, and this will cause the TLA dependency to be skipped because it's evaluating `barrel` as if `x` is not being imported. This will cause a corrupted state where `barrel` will be marked with evaluation, but TLA is still as `Linked`. Eventually, the assertion on [EvaluateModuleSync](https://tc39.es/proposal-deferred-reexports/#sec-EvaluateModuleSync) `4. Assert: promise.[[PromiseState]] is either fulfilled or rejected.` will fail once we try to execute `ns.x`.

~Given that, we are properly setting `ALL` as `importedNames` at this call site.~

The idea for this change is that we gather all asynchronous dependencies from module loaded from `import("graph_with_tla")`, like we do when evaluating `import * as ns from "graph_with_tla"`.