### PR TITLE
feat: adding support for filtered namespace on import calls

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -225,26 +225,24 @@ contributors: Nicolò Ribaudo
             1. <ins>Let _filter_ be Completion(Get(_options_, *"filter"*)).</ins>
             1. <ins>IfAbruptRejectPromise(_filter_, _promiseCapability_).</ins>
             1. <ins>If _filter_ is not *undefined*, then</ins>
-              1. <ins>Let _filterIsArray_ be Completion(IsArray(_filter_)).</ins>
-              1. <ins>IfAbruptRejectPromise(_filterIsArray_, _promiseCapability_).</ins>
-              1. <ins>If _filterIsArray_ is *false*, then</ins>
+              1. <ins>If _filter_ is not an Object, then</ins>
                 1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
                 1. <ins>Return _promiseCapability_.[[Promise]].</ins>
-              1. <ins>Let _length_ be Completion(LengthOfArrayLike(_filter_)).</ins>
-              1. <ins>IfAbruptRejectPromise(_length_, _promiseCapability_).</ins>
+              1. <ins>Let _iteratorRecord_ be Completion(GetIterator(_filter_, ~sync~)).</ins>
+              1. <ins>IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).</ins>
               1. <ins>Let _names_ be a new empty List.</ins>
-              1. <ins>Let _index_ be 0.</ins>
-              1. <ins>Repeat, while _index_ &lt; _length_,</ins>
-                1. <ins>Let _name_ be Completion(Get(_filter_, ! ToString(𝔽(_index_)))).</ins>
-                1. <ins>IfAbruptRejectPromise(_name_, _promiseCapability_).</ins>
-                1. <ins>If _name_ is not a String, then</ins>
-                  1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
-                  1. <ins>Return _promiseCapability_.[[Promise]].</ins>
-                1. <ins>If _names_ contains _name_, then</ins>
-                  1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
-                  1. <ins>Return _promiseCapability_.[[Promise]].</ins>
-                1. <ins>Append _name_ to _names_.</ins>
-                1. <ins>Set _index_ to _index_ + 1.</ins>
+              1. <ins>Let _done_ be *false*.</ins>
+              1. <ins>Repeat, while _done_ is *false*,</ins>
+                1. <ins>Let _next_ be Completion(IteratorStepValue(_iteratorRecord_)).</ins>
+                1. <ins>IfAbruptRejectPromise(_next_, _promiseCapability_).</ins>
+                1. <ins>If _next_ is ~done~, then</ins>
+                  1. <ins>Set _done_ to *true*.</ins>
+                1. <ins>Else if _next_ is not a String, then</ins>
+                  1. <ins>Let _error_ be ThrowCompletion(a newly created *TypeError* object).</ins>
+                  1. <ins>Let _closeResult_ be Completion(IteratorClose(_iteratorRecord_, _error_)).</ins>
+                  1. <ins>IfAbruptRejectPromise(_closeResult_, _promiseCapability_).</ins>
+                1. <ins>Else if _names_ does not contain _next_, then</ins>
+                  1. <ins>Append _next_ to _names_.</ins>
               1. <ins>Set _importedNames_ to _names_.</ins>
           1. Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Attributes]]: _attributes_, [[Phase]]: _phase_, <ins>[[ImportedNames]]: _importedNames_</ins> }.
           1. Perform HostLoadImportedModule(_referrer_, _moduleRequest_, ~empty~, _promiseCapability_).

--- a/spec.emu
+++ b/spec.emu
@@ -302,7 +302,7 @@ contributors: Nicolò Ribaudo
                 1. <del>Let _evaluatePromise_ be _module_.Evaluate().</del>
               1. <ins>If _phase_ is ~defer~, let _evaluationList_ be GatherAsynchronousTransitiveDependencies(_module_).</ins>
               1. <ins>Else, let _evaluationList_ be « _module_ ».</ins>
-              1. <ins>Let _optionalIndirectRequests_ be _module_.GetOptionalIndirectExportsModuleRequests(~all~).</ins>
+              1. <ins>Let _optionalIndirectRequests_ be _module_.GetOptionalIndirectExportsModuleRequests(_importedNames_).</ins>
               1. <ins>Perform ListAppendUnique(_evaluationList_, GatherAsynchronousTransitiveDependenciesForRequests(_module_, _optionalIndirectRequests_, « »)).</ins>
               1. <ins>If _evaluationList_ is empty, then</ins>
                 1. <ins>Assert: _phase_ is ~defer~.</ins>

--- a/spec.emu
+++ b/spec.emu
@@ -283,7 +283,7 @@ contributors: Nicolò Ribaudo
                 1. <ins>For each String _name_ of _importedNames_, do</ins>
                   1. <ins>Let _resolvable_ be Completion(EnsureResolvableBinding(_module_, _name_, ~disallow-ambiguous~)).</ins>
                   1. <ins>If _resolvable_ is an abrupt completion, then</ins>
-                    1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _resolvable_.[[Value]] &raquo;).</ins>
+                    1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « a newly created *ReferenceError* object »).</ins>
                     1. <ins>Return ~unused~.</ins>
               1. Let _fulfilledClosure_ be a new Abstract Closure with no parameters that captures _module_, _phase_, <ins>_importedNames_,</ins> and _promiseCapability_ and performs the following steps when called:
                 1. Let _namespace_ be GetModuleNamespace(_module_, _phase_, <ins>_importedNames_</ins>).

--- a/spec.emu
+++ b/spec.emu
@@ -240,7 +240,9 @@ contributors: Nicolò Ribaudo
                 1. <ins>Else if _next_ is not a String, then</ins>
                   1. <ins>Let _error_ be ThrowCompletion(a newly created *TypeError* object).</ins>
                   1. <ins>Let _closeResult_ be Completion(IteratorClose(_iteratorRecord_, _error_)).</ins>
-                  1. <ins>IfAbruptRejectPromise(_closeResult_, _promiseCapability_).</ins>
+                  1. <ins>Assert: _closeResult_ and _error_ are the same Completion Record.</ins>
+                  1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _error_.[[Value]] »).</ins>
+                  1. <ins>Return _promiseCapability_.[[Promise]].</ins>
                 1. <ins>Else if _names_ does not contain _next_, then</ins>
                   1. <ins>Append _next_ to _names_.</ins>
               1. <ins>Set _importedNames_ to _names_.</ins>

--- a/spec.emu
+++ b/spec.emu
@@ -222,13 +222,13 @@ contributors: Nicolò Ribaudo
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « a newly created *TypeError* object »).
               1. Return _promiseCapability_.[[Promise]].
             1. Sort _attributes_ according to the lexicographic order of their [[Key]] field, treating the value of each such field as a sequence of UTF-16 code unit values. NOTE: This sorting is observable only in that hosts are prohibited from changing behaviour based on the order in which attributes are enumerated.
-            1. <ins>Let _filter_ be Completion(Get(_options_, *"filter"*)).</ins>
-            1. <ins>IfAbruptRejectPromise(_filter_, _promiseCapability_).</ins>
-            1. <ins>If _filter_ is not *undefined*, then</ins>
-              1. <ins>If _filter_ is not an Object, then</ins>
+            1. <ins>Let _exports_ be Completion(Get(_options_, *"exports"*)).</ins>
+            1. <ins>IfAbruptRejectPromise(_exports_, _promiseCapability_).</ins>
+            1. <ins>If _exports_ is not *undefined*, then</ins>
+              1. <ins>If _exports_ is not an Object, then</ins>
                 1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
                 1. <ins>Return _promiseCapability_.[[Promise]].</ins>
-              1. <ins>Let _iteratorRecord_ be Completion(GetIterator(_filter_, ~sync~)).</ins>
+              1. <ins>Let _iteratorRecord_ be Completion(GetIterator(_exports_, ~sync~)).</ins>
               1. <ins>IfAbruptRejectPromise(_iteratorRecord_, _promiseCapability_).</ins>
               1. <ins>Let _names_ be a new empty List.</ins>
               1. <ins>Let _done_ be *false*.</ins>
@@ -277,6 +277,12 @@ contributors: Nicolò Ribaudo
               1. If _link_ is an abrupt completion, then
                 1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _link_.[[Value]] &raquo;).
                 1. Return ~unused~.
+              1. <ins>If _importedNames_ is a List of Strings, then</ins>
+                1. <ins>For each String _name_ of _importedNames_, do</ins>
+                  1. <ins>Let _resolvable_ be Completion(EnsureResolvableBinding(_module_, _name_, ~disallow-ambiguous~)).</ins>
+                  1. <ins>If _resolvable_ is an abrupt completion, then</ins>
+                    1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _resolvable_.[[Value]] &raquo;).</ins>
+                    1. <ins>Return ~unused~.</ins>
               1. Let _fulfilledClosure_ be a new Abstract Closure with no parameters that captures _module_, _phase_, <ins>_importedNames_,</ins> and _promiseCapability_ and performs the following steps when called:
                 1. Let _namespace_ be GetModuleNamespace(_module_, _phase_, <ins>_importedNames_</ins>).
                 1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _namespace_ &raquo;).

--- a/spec.emu
+++ b/spec.emu
@@ -197,6 +197,7 @@ contributors: Nicolò Ribaudo
           1. Let _specifierString_ be Completion(ToString(_specifier_)).
           1. IfAbruptRejectPromise(_specifierString_, _promiseCapability_).
           1. Let _attributes_ be a new empty List.
+          1. <ins>Let _importedNames_ be ~all~.</ins>
           1. If _options_ is not *undefined*, then
             1. If _options_ is not an Object, then
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « a newly created *TypeError* object »).
@@ -221,7 +222,31 @@ contributors: Nicolò Ribaudo
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « a newly created *TypeError* object »).
               1. Return _promiseCapability_.[[Promise]].
             1. Sort _attributes_ according to the lexicographic order of their [[Key]] field, treating the value of each such field as a sequence of UTF-16 code unit values. NOTE: This sorting is observable only in that hosts are prohibited from changing behaviour based on the order in which attributes are enumerated.
-          1. Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Attributes]]: _attributes_, [[Phase]]: _phase_, <ins>[[ImportedNames]]: ~all~</ins> }.
+            1. <ins>Let _filter_ be Completion(Get(_options_, *"filter"*)).</ins>
+            1. <ins>IfAbruptRejectPromise(_filter_, _promiseCapability_).</ins>
+            1. <ins>If _filter_ is not *undefined*, then</ins>
+              1. <ins>Let _filterIsArray_ be Completion(IsArray(_filter_)).</ins>
+              1. <ins>IfAbruptRejectPromise(_filterIsArray_, _promiseCapability_).</ins>
+              1. <ins>If _filterIsArray_ is *false*, then</ins>
+                1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
+                1. <ins>Return _promiseCapability_.[[Promise]].</ins>
+              1. <ins>Let _length_ be Completion(LengthOfArrayLike(_filter_)).</ins>
+              1. <ins>IfAbruptRejectPromise(_length_, _promiseCapability_).</ins>
+              1. <ins>Let _names_ be a new empty List.</ins>
+              1. <ins>Let _index_ be 0.</ins>
+              1. <ins>Repeat, while _index_ &lt; _length_,</ins>
+                1. <ins>Let _name_ be Completion(Get(_filter_, ! ToString(𝔽(_index_)))).</ins>
+                1. <ins>IfAbruptRejectPromise(_name_, _promiseCapability_).</ins>
+                1. <ins>If _name_ is not a String, then</ins>
+                  1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
+                  1. <ins>Return _promiseCapability_.[[Promise]].</ins>
+                1. <ins>If _names_ contains _name_, then</ins>
+                  1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</ins>
+                  1. <ins>Return _promiseCapability_.[[Promise]].</ins>
+                1. <ins>Append _name_ to _names_.</ins>
+                1. <ins>Set _index_ to _index_ + 1.</ins>
+              1. <ins>Set _importedNames_ to _names_.</ins>
+          1. Let _moduleRequest_ be a new ModuleRequest Record { [[Specifier]]: _specifierString_, [[Attributes]]: _attributes_, [[Phase]]: _phase_, <ins>[[ImportedNames]]: _importedNames_</ins> }.
           1. Perform HostLoadImportedModule(_referrer_, _moduleRequest_, ~empty~, _promiseCapability_).
           1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
@@ -232,6 +257,7 @@ contributors: Nicolò Ribaudo
               _promiseCapability_: a PromiseCapability Record,
               _moduleCompletion_: either a normal completion containing a Module Record or a throw completion,
               _phase_: ~defer~ or ~evaluation~,
+              <ins>_importedNames_: ~all~ or a List of Strings,</ins>
             ): ~unused~
           </h1>
           <dl class="header">
@@ -243,18 +269,18 @@ contributors: Nicolò Ribaudo
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _moduleCompletion_.[[Value]] &raquo;).
               1. Return ~unused~.
             1. Let _module_ be _moduleCompletion_.[[Value]].
-            1. Let _loadPromise_ be _module_.LoadRequestedModules(<ins>~all~</ins>).
+            1. Let _loadPromise_ be _module_.LoadRequestedModules(<ins>_importedNames_</ins>).
             1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _promiseCapability_ and performs the following steps when called:
               1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _reason_ &raquo;).
               1. Return ~unused~.
             1. Let _onRejected_ be CreateBuiltinFunction(_rejectedClosure_, 1, *""*, &laquo; &raquo;).
-            1. Let _linkAndEvaluateClosure_ be a new Abstract Closure with no parameters that captures _module_, _promiseCapability_, _phase_ and _onRejected_ and performs the following steps when called:
-              1. Let _link_ be Completion(_module_.Link(<ins>~all~</ins>)).
+            1. Let _linkAndEvaluateClosure_ be a new Abstract Closure with no parameters that captures _module_, _promiseCapability_, _phase_<ins>, _importedNames_</ins> and _onRejected_ and performs the following steps when called:
+              1. Let _link_ be Completion(_module_.Link(<ins>_importedNames_</ins>)).
               1. If _link_ is an abrupt completion, then
                 1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _link_.[[Value]] &raquo;).
                 1. Return ~unused~.
-              1. Let _fulfilledClosure_ be a new Abstract Closure with no parameters that captures _module_, _phase_, and _promiseCapability_ and performs the following steps when called:
-                1. Let _namespace_ be GetModuleNamespace(_module_, _phase_, <ins>~all~</ins>).
+              1. Let _fulfilledClosure_ be a new Abstract Closure with no parameters that captures _module_, _phase_, <ins>_importedNames_,</ins> and _promiseCapability_ and performs the following steps when called:
+                1. Let _namespace_ be GetModuleNamespace(_module_, _phase_, <ins>_importedNames_</ins>).
                 1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _namespace_ &raquo;).
                 1. Return ~unused~.
               1. <del>If _phase_ is ~defer~, then </del>
@@ -2600,7 +2626,7 @@ contributors: Nicolò Ribaudo
           1. If _payload_ is a GraphLoadingState Record, then
             1. Perform ContinueModuleLoading(_payload_, _result_, <ins>_moduleRequest_.[[ImportedNames]]</ins>).
           1. Else,
-            1. Perform ContinueDynamicImport(_payload_, _result_, _moduleRequest_.[[Phase]]).
+            1. Perform ContinueDynamicImport(_payload_, _result_, _moduleRequest_.[[Phase]], <ins>_moduleRequest_.[[ImportedNames]]</ins>).
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
This is adding support for filtered namespaces from import calls. Ao far the API is like `import("mod",  { filter: ["foo", "bar"] });` (name to be defined on #39). The semantics here is that we just accept an object with iterator protocol that returns an array of strings. If other type of key is given, it throws a `TypeError`.